### PR TITLE
Export RenderOptions from main

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,3 +63,5 @@ const validateOptions = (options: RenderOptions) => {
   }
   return Object.assign({}, DEFAULT_OPTIONS, options);
 };
+
+export { RenderOptions };


### PR DESCRIPTION
Hey there, thanks for creating and maintaining this package 👍 Here's a tiny PR which I think would improve this package. Let me know what you think.

# What

Export the `RenderOptions` type directly from `src/index.ts`.

# Why

If we want to use `RenderOptions` outside of the package, we have to do this now:

```ts
import Urlbox from 'urlbox'
import type { RenderOptions } from 'urlbox/dist/mjs/types'
```

But with this PR merged, we need only do:

```ts
import Urlbox, { RenderOptions } from 'urlbox'
```

Cheers!