### PR TITLE
Update index.ts to use new node:crypto package ref

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 "use strict";
 import qs from "qs";
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { RenderOptions } from "./types";
 
 const DEFAULT_PREFIX = "https://api.urlbox.io/v1/";


### PR DESCRIPTION
change ref to node:crypto

This is required for use on Cloudflare pages:
https://developers.cloudflare.com/workers/runtime-apis/nodejs/crypto/